### PR TITLE
fixed use of constant in docBlock to be consistent with style docs

### DIFF
--- a/addon/components/block-slot.js
+++ b/addon/components/block-slot.js
@@ -12,7 +12,7 @@ const {
  * The maximum allowed number of block parameters supported
  *
  * @memberof module:addon/components/block-slot
- * @const {Number} blockParamsAllowed
+ * @constant {Number} blockParamsAllowed
  * @default 10
  */
 const blockParamsAllowed = 10


### PR DESCRIPTION
# fix

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ciena-blueplanet/ember-block-slots/6)

<!-- Reviewable:end -->
