### PR TITLE
Refactor Array.from so instead we define each computed property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
-  firefox: "latest"
 env:
   matrix:
   - EMBER_TRY_SCENARIO=default

--- a/addon/components/block-slot.js
+++ b/addon/components/block-slot.js
@@ -4,18 +4,8 @@ import layout from '../templates/components/block-slot'
 const {
   assert,
   Component,
-  computed,
-  defineProperty
+  computed
 } = Ember
-
-/**
- * The maximum allowed number of block parameters supported
- *
- * @memberof module:addon/components/block-slot
- * @constant {Number} blockParamsAllowed
- * @default 10
- */
-const blockParamsAllowed = 10
 
 /**
  * @module
@@ -52,6 +42,115 @@ const component = Component.extend({
     return this.get('name') === this.get('yieldedSlotName')
   }),
 
+  // TODO In order to match the standard block params syntax we need
+  // to be able to pass a spread of positional params to the yield
+  // https://github.com/wycats/handlebars.js/pull/1149
+  //
+  // Until then we either have to use a hash, which changes the block
+  // param syntax for the slots, or a finite number of params passed
+  // directly to the yield, which is what we've opted for since it
+  // maintains the block param syntax
+
+  /**
+   * The first parameter of the yield
+   *
+   * @function
+   * @returns {Array|Boolean|Object|String}
+   */
+  p0: computed('yieldedSlot.params.[]', function () {
+    return this.get('yieldedSlot.params').objectAt(0)
+  }),
+
+  /**
+   * The second parameter of the yield
+   *
+   * @function
+   * @returns {Array|Boolean|Object|String}
+   */
+  p1: computed('yieldedSlot.params.[]', function () {
+    return this.get('yieldedSlot.params').objectAt(1)
+  }),
+
+  /**
+   * The third parameter of the yield
+   *
+   * @function
+   * @returns {Array|Boolean|Object|String}
+   */
+  p2: computed('yieldedSlot.params.[]', function () {
+    return this.get('yieldedSlot.params').objectAt(2)
+  }),
+
+  /**
+   * The fourth parameter of the yield
+   *
+   * @function
+   * @returns {Array|Boolean|Object|String}
+   */
+  p3: computed('yieldedSlot.params.[]', function () {
+    return this.get('yieldedSlot.params').objectAt(3)
+  }),
+
+  /**
+   * The fifth parameter of the yield
+   *
+   * @function
+   * @returns {Array|Boolean|Object|String}
+   */
+  p4: computed('yieldedSlot.params.[]', function () {
+    return this.get('yieldedSlot.params').objectAt(4)
+  }),
+
+  /**
+   * The sixth parameter of the yield
+   *
+   * @function
+   * @returns {Array|Boolean|Object|String}
+   */
+  p5: computed('yieldedSlot.params.[]', function () {
+    return this.get('yieldedSlot.params').objectAt(5)
+  }),
+
+  /**
+   * The seventh parameter of the yield
+   *
+   * @function
+   * @returns {Array|Boolean|Object|String}
+   */
+  p6: computed('yieldedSlot.params.[]', function () {
+    return this.get('yieldedSlot.params').objectAt(6)
+  }),
+
+  /**
+   * The eighth parameter of the yield
+   *
+   * @function
+   * @returns {Array|Boolean|Object|String}
+   */
+  p7: computed('yieldedSlot.params.[]', function () {
+    return this.get('yieldedSlot.params').objectAt(7)
+  }),
+
+  /**
+   * The ninth parameter of the yield
+   *
+   * @function
+   * @returns {Array|Boolean|Object|String}
+   */
+  p8: computed('yieldedSlot.params.[]', function () {
+    return this.get('yieldedSlot.params').objectAt(8)
+  }),
+
+  /**
+   * The tenth parameter of the yield
+   *
+   * @function
+   * @returns {Array|Boolean|Object|String}
+   */
+  p9: computed('yieldedSlot.params.[]', function () {
+    return this.get('yieldedSlot.params').objectAt(9)
+  }),
+
   /**
    * init event hook
    *
@@ -74,20 +173,6 @@ const component = Component.extend({
     // We're using parentView to avoid passing register on each yield slot,
     // maybe a helper can handle this?
     this.parentView._registerSlot(this.name)
-
-    // TODO In order to match the standard block params syntax we need
-    // to be able to pass a spread of positional params to the yield
-    // https://github.com/wycats/handlebars.js/pull/1149
-    //
-    // Until then we either have to use a hash, which changes the block
-    // param syntax for the slots, or a finite number of params passed
-    // directly to the yield, which is what we've opted for since it
-    // maintains the block param syntax
-    Array.from(Array(blockParamsAllowed).keys()).forEach((index) => {
-      defineProperty(this, `p${index}`, computed(function () {
-        return this.get('yieldedSlot.params').objectAt(index)
-      }))
-    })
   }
 })
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.5.0",
     "ember-try": "^0.2.2",
-    "eslint": "2.8.0",
+    "eslint": "^2.10.2",
     "eslint-config-frost-standard": "^2.0.0",
     "loader.js": "^4.0.1",
     "markdown-code-highlighting": "0.0.6"

--- a/tests/unit/components/block-slot-test.js
+++ b/tests/unit/components/block-slot-test.js
@@ -142,7 +142,7 @@ describeComponent(
       ).to.be.false
     })
 
-    it('Only 10 computed properties can be dynamically generated', function () {
+    it('Only 10 computed properties are generated', function () {
       const spy = sinon.spy()
 
       const slotObject = Ember.Object.create({
@@ -172,39 +172,6 @@ describeComponent(
       expect(
         component.get('p10'),
         '"p10" computed property is not created'
-      ).to.be.undefined
-    })
-
-    it('Correct number of computed properties are dynamically generated', function () {
-      const spy = sinon.spy()
-
-      const slotObject = Ember.Object.create({
-        params: Ember.A(
-          [ '0', '1', '2' ]
-        )
-      })
-
-      const parentViewObject = Ember.Object.create({
-        name: 'testName',
-        _registerSlot: spy
-      })
-
-      const component = this.subject({
-        name: 'testName',
-        yieldedSlot: slotObject,
-        parentView: parentViewObject
-      })
-
-      _.range(3).forEach((number) => {
-        expect(
-          component.get(`p${number}`),
-          `"p${number}" computed property gets set`
-        ).to.eql(`${number}`)
-      })
-
-      expect(
-        component.get('p3'),
-        '"p3" computed property is not created'
       ).to.be.undefined
     })
   }


### PR DESCRIPTION
# PATCH

Closes: https://github.com/ciena-blueplanet/ember-block-slots/issues/24
# CHANGELOG
- **Updated** Array.from usage and instead we define each computed property for yieldedSlot.params.
- **Removed** Unit test for block-slot component since we do not need to verify the number of yieldedSlot.params being generated dynamically.
- **Removed** Entry in travis.yml to run on the latest version of Firefox.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ciena-blueplanet/ember-block-slots/25)

<!-- Reviewable:end -->
