### PR TITLE
Adding ember-prop-types to the addon blueprint

### DIFF
--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,6 +1,0 @@
-{
-  "predef": [
-    "console"
-  ],
-  "strict": false
-}

--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/ember-block-slots/index.js
+++ b/blueprints/ember-block-slots/index.js
@@ -1,0 +1,12 @@
+module.exports = {
+  description: '',
+  normalizeEntityName: function () {},
+
+  afterInstall: function () {
+    return this.addAddonsToProject({
+      packages: [
+        {name: 'ember-prop-types', target: '^2.0.0'}
+      ]
+    })
+  }
+}


### PR DESCRIPTION
# fix# for #33
# CHANGELOG
- Added ember-prop-types to the addon blueprint to install the dependency during `ember install`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ciena-blueplanet/ember-block-slots/36)

<!-- Reviewable:end -->
