### PR TITLE
fixed yield-slot isActive throwing error when wrapped in component

### DIFF
--- a/addon/components/yield-slot.js
+++ b/addon/components/yield-slot.js
@@ -5,6 +5,7 @@ const {
 } = Ember
 import layout from '../templates/components/yield-slot'
 import { PropTypes } from 'ember-prop-types'
+import Slots from '../mixins/slots'
 
 /**
  * {{yield-slot}} provides a target for {{block-slot}} content
@@ -52,8 +53,8 @@ const YieldSlotComponent = Component.extend({
 
   // Use nearestOfType to determine the parent view, just in case there are
   // other components sandwiched between the block slot and the Slots mixin
-  _parentView: computed(function() {
-     return this.nearestOfType(Slots)
+  _parentView: computed(function () {
+    return this.nearestOfType(Slots)
   }),
 
   // A yield slot is considered active if a block slot registered a matching

--- a/addon/components/yield-slot.js
+++ b/addon/components/yield-slot.js
@@ -50,10 +50,16 @@ const YieldSlotComponent = Component.extend({
 
   // == Computed properties ===================================================
 
+  // Use nearestOfType to determine the parent view, just in case there are
+  // other components sandwiched between the block slot and the Slots mixin
+  _parentView: computed(function() {
+     return this.nearestOfType(Slots)
+  }),
+
   // A yield slot is considered active if a block slot registered a matching
   // name against the parent component with the Slots mixin
-  isActive: computed('parentView._slots.[]', '_name', function () {
-    return this.get('parentView._slots').contains(this.get('_name'))
+  isActive: computed('_parentView._slots.[]', '_name', function () {
+    return this.get('_parentView._slots').contains(this.get('_name'))
   })
 })
 


### PR DESCRIPTION
# fix# for #30.

Trying to write a test as well, but `ember test` is behaving weirdly for me. Still working through it.
# Changelog
- Yield slots will now find the nearest component with slots to register against - a direct parent with slots is no longer required

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ciena-blueplanet/ember-block-slots/38)

<!-- Reviewable:end -->
