### PR TITLE
Fixing deprecation of contains

### DIFF
--- a/addon/mixins/slots.js
+++ b/addon/mixins/slots.js
@@ -21,6 +21,6 @@ export default Mixin.create({
     this.get('_slots').removeObject(name)
   },
   _isRegistered (name) {
-    return this.get('_slots').contains(name)
+    return this.get('_slots').includes(name)
   }
 })

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "ember-one-way-controls": "0.8.3",
     "ember-redux": "1.4.0",
     "ember-resolver": "^2.0.3",
-    "ember-runtime-enumerable-includes-polyfill": "^1.0.1",
     "ember-truth-helpers": "1.2.0",
     "ember-try": "^0.2.2",
     "eslint": "^2.10.2",
@@ -70,7 +69,8 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-prop-types": "^2.0.0"
+    "ember-prop-types": "^2.0.0",
+    "ember-runtime-enumerable-includes-polyfill": "^1.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "ember-one-way-controls": "0.8.3",
     "ember-redux": "1.4.0",
     "ember-resolver": "^2.0.3",
+    "ember-runtime-enumerable-includes-polyfill": "^1.0.1",
     "ember-truth-helpers": "1.2.0",
     "ember-try": "^0.2.2",
     "eslint": "^2.10.2",


### PR DESCRIPTION
# fix
# Changelog
- Use includes method over contains to fix deprecation in Ember 2.8

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ciena-blueplanet/ember-block-slots/41)

<!-- Reviewable:end -->
