### PR TITLE
Convert contains to include to fix deprecation

### DIFF
--- a/addon/components/yield-slot.js
+++ b/addon/components/yield-slot.js
@@ -60,7 +60,7 @@ const YieldSlotComponent = Component.extend({
   // A yield slot is considered active if a block slot registered a matching
   // name against the parent component with the Slots mixin
   isActive: computed('_parentView._slots.[]', '_name', function () {
-    return this.get('_parentView._slots').contains(this.get('_name'))
+    return this.get('_parentView._slots').includes(this.get('_name'))
   })
 })
 


### PR DESCRIPTION
# fix
# Changelog
- Forgot one instance where contains was used. Converting that to includes fixes the deprecations in 2.8.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ciena-blueplanet/ember-block-slots/42)

<!-- Reviewable:end -->
