### PR TITLE
Fix for #43

### DIFF
--- a/addon/helpers/block-params.js
+++ b/addon/helpers/block-params.js
@@ -25,7 +25,7 @@ const {
  * <div>a b c</div>
  */
 export function blockParams (params) {
-  return A(params)
+  return A(params.slice())
 }
 
 export default Helper.helper(blockParams)


### PR DESCRIPTION
#fix#

# Changelog
* 2.10.0 now freezes params, need to clone Array before `Ember.A`ing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ciena-blueplanet/ember-block-slots/44)
<!-- Reviewable:end -->
