### PR TITLE
Bug: Not Compatible with 2.10 (Glimmer 2)

### DIFF
--- a/addon/components/block-slot.js
+++ b/addon/components/block-slot.js
@@ -37,7 +37,7 @@ const BlockSlot = Component.extend({
 
   // == Events ================================================================
 
-  _init: on('init', function () {
+  _didInsertElement: on('didInsertElement', function () {
     // Active the yield slot using the slots interface
     const slottedComponent = this.nearestOfType(Slots)
     if (!slottedComponent._isRegistered(this._name)) {


### PR DESCRIPTION

**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

Delay the initialization of the `block-slot` to the `didInsertElement` callback.

`Assertion Failed: You modified "isActive" twice on <xxx@component:yield-slot::ember1525> in a single render. It was rendered in "component:yield-slot" and modified in "component:block-slot". This was unreliable and slow in Ember 1.x and is no longer supported. See https://github.com/emberjs/ember.js/issues/13948 for more details.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ciena-blueplanet/ember-block-slots/50)
<!-- Reviewable:end -->
