### PR TITLE
Upgrade ember-runtime-enumerable-includes-polyfill to 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-- '5.0'
+- '6.0'
 - 'stable'
 branches:
   except:

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-prop-types": ">=2.0.0 <4.0.0",
-    "ember-runtime-enumerable-includes-polyfill": "^1.0.1"
+    "ember-runtime-enumerable-includes-polyfill": "^2.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

The only changes to ember-runtime-enumerable-includes-polyfill for 2.0.0 is moving to Babel 6. As covered in #48, we lint dependencies at Salsify and would like to remove our overrides for this project

# CHANGELOG

Upgrade ember-runtime-enumerable-includes-polyfill to 2.0.0
